### PR TITLE
Add port option

### DIFF
--- a/rio_glui/cli.py
+++ b/rio_glui/cli.py
@@ -118,7 +118,8 @@ def set_source():
 @click.argument('srcpath', type=click.Path(exists=True))
 @click.option('--shape', type=int, default=512)
 @click.option('--tile-size', type=int, default=512)
-def glui(srcpath, shape, tile_size):
+@click.option('--prt', type=int, default=5000)
+def glui(srcpath, shape, tile_size, prt):
     pk.start(srcpath, shape, tile_size)
-    click.echo('Inspecting {0} at http://127.0.0.1:5000/'.format(srcpath), err=True)
-    app.run(threaded=True)
+    click.echo('Inspecting {0} at http://127.0.0.1:{1}/'.format(srcpath, prt), err=True)
+    app.run(threaded=True, port=prt)


### PR DESCRIPTION
Adds a port option `--prt` to commands. This makes it easy to inspect and compare multiple scenes using different ports.