### PR TITLE
Latest rasterio

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 click
-rasterio
+"rasterio>=1.0a9"
 Pillow
 flask
 mercantile


### PR DESCRIPTION
Changed the default `rasterio` in requirement to the version that works 👍  on python 3.6