### PR TITLE
Decrashify

### DIFF
--- a/rio_glui/cli.py
+++ b/rio_glui/cli.py
@@ -48,10 +48,13 @@ class Peeker:
     def get_ctr_lat(self):
         return (self.wgs_bounds[3] - self.wgs_bounds[1]) / 2 + self.wgs_bounds[1]
 
-    # @lru_cache()
+    @lru_cache()
     def get_tile(self, z, x, y):
-        bounds = [c for i in (mercantile.xy(*mercantile.ul(x, y + 1, z)), mercantile.xy(*mercantile.ul(x + 1, y, z))) for c in i]
-        toaffine = transform.from_bounds(*bounds + [self.img_dimension, self.img_dimension])
+        bounds = [c for i in (
+            mercantile.xy(*mercantile.ul(x, y + 1, z)),
+            mercantile.xy(*mercantile.ul(x + 1, y, z))) for c in i]
+        toaffine = transform.from_bounds(
+            *bounds + [self.img_dimension, self.img_dimension])
 
         with rio.open(self.path) as src:
             source_arr = src.read()


### PR DESCRIPTION
Fixes #13 

Good news is I think the scenetif is ok. We had opened the dataset, assigned it as a property of a `Peeker` object which was passed to multiple flask threads. Not sure *exactly* what was going wrong but definitely related to thread safety, hence the intermittent weirdness. Per @sgillies chat:
> you can't share a rasterio dataset object (or GDAL dataset handle) among threads

The **solution** is to open the dataset separately in each `get_tile` method call, using a `with` context block to make sure it gets closed out.

<hr> 

As an aside, some changes not related to the actual fix but worth keeping I think. If the noise is too much, I can pull these fixes out into a separate PR...

* Reproject the entire array at once rather than per band
* the CLI will automatically open the URL in your browser for you
* misc formatting tweaks and import shuffling