### PR TITLE
Include cachetools in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
-click
-rasterio>=1.0a10
 Pillow
+cachetools
+click
 flask
 mercantile>=0.10.0
+rasterio>=1.0a10
 rio-color


### PR DESCRIPTION
Currently, `pip install -e .` with a fresh virtualenv results in:
```bash
$ rio-glui master rio glui --help
Usage: rio glui [OPTIONS]

  Warning: entry point could not be loaded. Contact its author for help.

  Traceback (most recent call last):
    File "/Users/jacques/.pyenv/versions/3.6.1/envs/rio-glui/lib/python3.6/site-packages/click_plugins/core.py", line 37, in decorator
      group.add_command(entry_point.load())
    File "/Users/jacques/.pyenv/versions/3.6.1/envs/rio-glui/lib/python3.6/site-packages/pkg_resources/__init__.py", line 2291, in load
      return self.resolve()
    File "/Users/jacques/.pyenv/versions/3.6.1/envs/rio-glui/lib/python3.6/site-packages/pkg_resources/__init__.py", line 2297, in resolve
      module = __import__(self.module_name, fromlist=['__name__'], level=0)
    File "/Users/jacques/code/mapbox/rio-glui/rio_glui/cli.py", line 5, in <module>
      from cachetools.func import lru_cache
  ModuleNotFoundError: No module named 'cachetools'

Options:
  --help  Show this message and exit.
```

cc @virginiayung 