### PR TITLE
Remove pypi releasing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,11 +22,3 @@ script:
   - tox
 after_success:
   - if [[ $TRAVIS_PYTHON_VERSION == 3.6 ]]; then coverage xml; codecov; fi
-deploy:
-  on:
-    repo: mapbox/rio-glui
-    python: 3.6
-    tags: true
-  provider: pypi
-  distributions: "sdist bdist_wheel"
-  user: mapboxci


### PR DESCRIPTION
The existing configuration is out of date. Since we have no future releases planned, I propose to remove the configuration instead of updating it.

@pratikyadav review please?