### PR TITLE
Update densify_pts param

### DIFF
--- a/rio_glui/raster.py
+++ b/rio_glui/raster.py
@@ -61,7 +61,7 @@ class RasterTiles(object):
 
             self.bounds = list(
                 transform_bounds(
-                    *[src.crs, "epsg:4326"] + list(src.bounds), densify_pts=0
+                    *[src.crs, "epsg:4326"] + list(src.bounds), densify_pts=21
                 )
             )
             self.indexes = indexes if indexes is not None else src.indexes


### PR DESCRIPTION
This is throwing errors in transform. Adjusting it to the GDAL default of 21 works here [and elsewhere](https://github.com/acalcutt/rio-rgbify/commit/6db4f8baf4d78e157e02c67b05afae49289f9ef1).